### PR TITLE
Update to the es_ES.json

### DIFF
--- a/es_ES.json
+++ b/es_ES.json
@@ -12,7 +12,7 @@
         "created": "Creado",
         "details": "Detalles",
         "difficulty": "Dificultad",
-        "fee": "Comisión ::: Comisiones",
+        "fee": "Fee ::: Comisiones",
         "fees_per_kb": "Comisiones por KB",
         "hash_rate": "Índice de procesamiento",
         "key_image": "Imagen de la clave",
@@ -35,16 +35,16 @@
         "stealth_address": "Dirección secreta",
         "time": "Tiempo",
         "transaction_id": "ID de la transacción",
-        "transaction": "Transacción ::: Transacciones",
+        "transaction": "transacción ::: transacciones",
         "transactions_total": "Total de transacciones",
         "transactions_queued": "Transacciones en cola",
         "testnet": "Testnet"
     },
     "forms": {
         "deposit_address": "Dirección de depósito",
-        "enter_deposit_address": "Introduzca su dirección de depósito...",
-        "secret_view_key": "Clave secreta de visualización",
-        "enter_secret_key": "Introduzca su clave secreta de visualización...",
+        "enter_deposit_address": "Introduzca la dirección de depósito...",
+        "secret_view_key": "Su clave secreta de visualización",
+        "enter_secret_key": "Introduzca la clave secreta de visualización...",
         "enter_transaction_id": "Introduzca el ID de la transacción...",
         "recipient_address": "Dirección del destinatario",
         "enter_recipient_address": "Introduzca la dirección del destinatario..",
@@ -118,7 +118,7 @@
         "page_title": "Recibo de depósito",
         "form": {
             "title": "Verificar si un depósito fue recibido",
-            "text": "Verificar que una transacción incluyo un depósito a una dirección especifica, y vea si ha sido confirmada por la red."
+            "text": "Verifique que una transacción incluyo un depósito a una dirección especifica, y vea si ha sido confirmada por la red."
         },
         "result": {
             "title": "Depósito confirmado",

--- a/es_ES.json
+++ b/es_ES.json
@@ -12,7 +12,7 @@
         "created": "Creado",
         "details": "Detalles",
         "difficulty": "Dificultad",
-        "fee": "Fee ::: Comisiones",
+        "fee": "Comisión ::: Comisiones",
         "fees_per_kb": "Comisiones por KB",
         "hash_rate": "Índice de procesamiento",
         "key_image": "Imagen de la clave",
@@ -35,7 +35,7 @@
         "stealth_address": "Dirección secreta",
         "time": "Tiempo",
         "transaction_id": "ID de la transacción",
-        "transaction": "transacción ::: transacciones",
+        "transaction": "Transacción ::: Transacciones",
         "transactions_total": "Total de transacciones",
         "transactions_queued": "Transacciones en cola",
         "testnet": "Testnet"


### PR DESCRIPTION
The changes are comprised on the "Update es_ES.json" commit. The "Capitalization and reviewing" commit can be ignored since it's only to re-capitalize and re-translate words that were already, but 'cause I used an old .json those changes were not enforced and thus had to be done again.

The real changes are to pursue a more neutral version of the Spanish Translation. The changes resume in:
- Replace "Introduzca su clave secreta de visualización..." and "Introduzca su clave secreta de visualización..." for "Introduzca la dirección de depósito..." and "Introduzca la clave secreta de visualización..." respectively. The use of the possessive adverb "su" is mainly used in this type of sentences in the Castilian dialect, so it is replaced by the article "la" which is more common in other Spanish dialects.
- Replace "Verificar que una transacción incluyo un depósito a una dirección especifica, y vea si ha sido confirmada por la red." for "Verifique que una transacción incluyo un depósito a una dirección especifica, y vea si ha sido confirmada por la red.". The same as the described change above, it's more common to every Spanish dialect to not use the root of the verb "Verificar". Because it's already used for the title of the section and is preferable to use a conjugation that refers to the user of the website, which in this case is the imperative for the third person of the singular "Verifique".